### PR TITLE
Fix scroll issues when moving elements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.19
 yarn_mappings=1.19+build.4
 loader_version=0.14.8
 # Mod Properties
-mod_version=0.0.7
+mod_version=0.0.8
 maven_group=com.peasenet
 archives_base_name=gavui
 # Dependencies

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,3 +8,4 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+rootProject.name = "gavui"

--- a/src/main/java/com/peasenet/gavui/Gui.java
+++ b/src/main/java/com/peasenet/gavui/Gui.java
@@ -24,8 +24,8 @@ import com.peasenet.gavui.color.Color;
 import com.peasenet.gavui.color.Colors;
 import com.peasenet.gavui.math.BoxD;
 import com.peasenet.gavui.math.PointD;
-import com.peasenet.gavui.util.GuiUtil;
 import com.peasenet.gavui.util.GavUISettings;
+import com.peasenet.gavui.util.GuiUtil;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.Text;
@@ -46,7 +46,7 @@ public class Gui {
     /**
      * The list of buttons(mods) in this dropdown.
      */
-    protected final ArrayList<Gui> children = new ArrayList<>();
+    protected ArrayList<Gui> children = new ArrayList<>();
     /**
      * The title of the gui.
      */
@@ -143,7 +143,7 @@ public class Gui {
      * Clears all children from this gui.
      */
     public void clearChildren() {
-        children.clear();
+        children = new ArrayList<>();
     }
 
     /**
@@ -188,6 +188,7 @@ public class Gui {
      */
     public void hide() {
         hidden = true;
+        children.forEach(Gui::hide);
     }
 
     /**
@@ -195,6 +196,7 @@ public class Gui {
      */
     public void show() {
         hidden = false;
+        children.forEach(Gui::show);
     }
 
     /**
@@ -264,8 +266,14 @@ public class Gui {
      * Shrinks this gui by 5.5 pixels to fit a scrollbar.
      */
     public void shrinkForScrollbar() {
-        if (!shrunkForScroll) setWidth(getWidth() - 10);
+        if (shrunkForScroll) return;
+        setWidth(getWidth() - 1);
         shrunkForScroll = true;
+    }
+
+    public void shrinkForScrollbar(Gui parent) {
+        if (this.getWidth() == parent.getWidth())
+            this.setWidth(parent.getWidth() - 5);
     }
 
     /**
@@ -294,6 +302,9 @@ public class Gui {
         if (symbol != '\0')
             tr.draw(matrixStack, String.valueOf(symbol), (int) getX2() + symbolOffsetX, (int) getY() + symbolOffsetY, (GavUISettings.getColor("gui.color.foreground")).getAsInt());
         GuiUtil.drawOutline(Colors.WHITE.getAsFloatArray(), (int) getX(), (int) getY(), (int) getX2(), (int) getY2() + 1, matrixStack);
+        if(hasChildren())
+            for(Gui c : children)
+                c.render(matrixStack,tr,mouseX,mouseY,delta);
     }
 
     /**
@@ -350,6 +361,8 @@ public class Gui {
      */
     public void setDragging(boolean dragging) {
         this.dragging = dragging;
+        for (Gui child : children)
+            child.setDragging(dragging);
     }
 
     /**

--- a/src/main/java/com/peasenet/gavui/Gui.java
+++ b/src/main/java/com/peasenet/gavui/Gui.java
@@ -272,8 +272,10 @@ public class Gui {
     }
 
     public void shrinkForScrollbar(Gui parent) {
+        if (shrunkForScroll) return;
         if (this.getWidth() == parent.getWidth())
-            this.setWidth(parent.getWidth() - 5);
+            this.setWidth(getWidth() - 5);
+        shrunkForScroll = true;
     }
 
     /**

--- a/src/main/java/com/peasenet/gavui/Gui.java
+++ b/src/main/java/com/peasenet/gavui/Gui.java
@@ -267,12 +267,12 @@ public class Gui {
      */
     public void shrinkForScrollbar() {
         if (shrunkForScroll) return;
-        setWidth(getWidth() - 1);
+        setWidth(getWidth() - 5);
         shrunkForScroll = true;
     }
 
     public void shrinkForScrollbar(Gui parent) {
-        if (shrunkForScroll) return;
+        if (shrunkForScroll && this.getWidth() == parent.getWidth()) return;
         if (this.getWidth() == parent.getWidth())
             this.setWidth(getWidth() - 5);
         shrunkForScroll = true;
@@ -304,9 +304,9 @@ public class Gui {
         if (symbol != '\0')
             tr.draw(matrixStack, String.valueOf(symbol), (int) getX2() + symbolOffsetX, (int) getY() + symbolOffsetY, (GavUISettings.getColor("gui.color.foreground")).getAsInt());
         GuiUtil.drawOutline(Colors.WHITE.getAsFloatArray(), (int) getX(), (int) getY(), (int) getX2(), (int) getY2() + 1, matrixStack);
-        if(hasChildren())
-            for(Gui c : children)
-                c.render(matrixStack,tr,mouseX,mouseY,delta);
+        if (hasChildren())
+            for (Gui c : children)
+                c.render(matrixStack, tr, mouseX, mouseY, delta);
     }
 
     /**
@@ -428,5 +428,12 @@ public class Gui {
      */
     public boolean hasChildren() {
         return !children.isEmpty();
+    }
+
+    public void setShrunkForScrollbar(boolean b) {
+        shrunkForScroll = b;
+        if(hasChildren())
+            for(Gui c : children)
+                c.setShrunkForScrollbar(b);
     }
 }

--- a/src/main/java/com/peasenet/gavui/Gui.java
+++ b/src/main/java/com/peasenet/gavui/Gui.java
@@ -264,7 +264,7 @@ public class Gui {
      * Shrinks this gui by 5.5 pixels to fit a scrollbar.
      */
     public void shrinkForScrollbar() {
-        if (!shrunkForScroll) setWidth(getWidth() - 5.5);
+        if (!shrunkForScroll) setWidth(getWidth() - 10);
         shrunkForScroll = true;
     }
 

--- a/src/main/java/com/peasenet/gavui/GuiClick.java
+++ b/src/main/java/com/peasenet/gavui/GuiClick.java
@@ -74,7 +74,7 @@ public class GuiClick extends Gui {
         var inGui = mouseWithinGui(mouseX, mouseY) && !isHidden();
         if (inGui && GavUISettings.getBool("gui.sound"))
             MinecraftClient.getInstance().player.playSound(SoundEvents.UI_BUTTON_CLICK, 0.5f, 1);
-        if (inGui && callback != null) callback.callback();
+        if (inGui && callback != null && !isHidden()) callback.callback();
 
         return inGui;
     }

--- a/src/main/java/com/peasenet/gavui/GuiDraggable.java
+++ b/src/main/java/com/peasenet/gavui/GuiDraggable.java
@@ -72,4 +72,13 @@ public class GuiDraggable extends GuiClick {
         setMidPoint(new PointD(mouseX, mouseY));
         return true;
     }
+    
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if(button == 1) {
+            setFrozen(!frozen());
+            return true;
+        }
+        return super.mouseClicked(mouseX, mouseY, button);
+    }
 }

--- a/src/main/java/com/peasenet/gavui/GuiDropdown.java
+++ b/src/main/java/com/peasenet/gavui/GuiDropdown.java
@@ -82,7 +82,7 @@ public class GuiDropdown extends GuiDraggable {
             var child = toRenderList.get(i);
             switch (getDirection()) {
                 case DOWN -> child.setPosition(new PointD(getX(), getY2() + 2 + (i * 12)));
-                case RIGHT -> child.setPosition(new PointD(getX2() + 2, getY() + (i * 12)));
+                case RIGHT -> child.setPosition(new PointD(getX2() + 6, getY() + (i * 12)));
             }
             child.render(matrixStack, tr, mouseX, mouseY, delta);
         }

--- a/src/main/java/com/peasenet/gavui/GuiDropdown.java
+++ b/src/main/java/com/peasenet/gavui/GuiDropdown.java
@@ -82,7 +82,7 @@ public class GuiDropdown extends GuiDraggable {
             var child = toRenderList.get(i);
             switch (getDirection()) {
                 case DOWN -> child.setPosition(new PointD(getX(), getY2() + 2 + (i * 12)));
-                case RIGHT -> child.setPosition(new PointD(getX2() + 6, getY() + (i * 12)));
+                case RIGHT -> child.setPosition(new PointD(getX2() + 10, getY() + (i * 12)));
             }
             child.render(matrixStack, tr, mouseX, mouseY, delta);
         }
@@ -164,10 +164,12 @@ public class GuiDropdown extends GuiDraggable {
      */
     private void resetDropdownsLocation() {
         // copy buttons to a new array
-        ArrayList<Gui> newButtons = new ArrayList<>(children);
-        children.clear();
-        // check if newbuttons contains any children
-        newButtons.forEach(this::addElement);
+        for(Gui element : children) {
+            if (getDirection() == Direction.RIGHT) {
+                element.setPosition(new PointD(getX2() + 12, getY2() + (children.size()) * 12));
+            }
+        }
+
     }
 
     /**
@@ -194,6 +196,7 @@ public class GuiDropdown extends GuiDraggable {
         if (getDirection() == Direction.RIGHT) {
             element.setPosition(new PointD(getX2() + 12, getY2() + (children.size()) * 12));
         }
+        element.setWidth(getWidth());
     }
 
     /**

--- a/src/main/java/com/peasenet/gavui/GuiDropdown.java
+++ b/src/main/java/com/peasenet/gavui/GuiDropdown.java
@@ -164,7 +164,7 @@ public class GuiDropdown extends GuiDraggable {
      */
     private void resetDropdownsLocation() {
         // copy buttons to a new array
-        for(Gui element : children) {
+        for (Gui element : children) {
             if (getDirection() == Direction.RIGHT) {
                 element.setPosition(new PointD(getX2() + 12, getY2() + (children.size()) * 12));
             }
@@ -209,11 +209,11 @@ public class GuiDropdown extends GuiDraggable {
         if (!isOpen()) {
             switch (getDirection()) {
                 case RIGHT -> {
-                    symbol = '▶';
+                    symbol = '\u25B6';
                     symbolOffsetX = -8;
                 }
                 case DOWN -> {
-                    symbol = '▼';
+                    symbol = '\u25BC';
                     symbolOffsetY = 3;
                     symbolOffsetX = -8;
                 }

--- a/src/main/java/com/peasenet/gavui/GuiDropdown.java
+++ b/src/main/java/com/peasenet/gavui/GuiDropdown.java
@@ -209,11 +209,11 @@ public class GuiDropdown extends GuiDraggable {
         if (!isOpen()) {
             switch (getDirection()) {
                 case RIGHT -> {
-                    symbol = '\u25B6';
+                    symbol = '▶';
                     symbolOffsetX = -8;
                 }
                 case DOWN -> {
-                    symbol = '\u25BC';
+                    symbol = '▼';
                     symbolOffsetY = 3;
                     symbolOffsetX = -8;
                 }

--- a/src/main/java/com/peasenet/gavui/GuiScroll.java
+++ b/src/main/java/com/peasenet/gavui/GuiScroll.java
@@ -106,9 +106,14 @@ public class GuiScroll extends GuiDropdown {
         else setBackground(GavUISettings.getColor("gui.color.background"));
         var offset = shouldDrawScrollBar() ? 5 : 0;
         GuiUtil.drawBox(getBackgroundColor().getAsFloatArray(), (int) getX(), (int) getY(), (int) getX2(), (int) getY2() + 1, matrixStack);
-        tr.draw(matrixStack, title, (int) getX() + 2, (int) getY() + 2, (GavUISettings.getColor("gui.color.foreground")).getAsInt());
+        var t = title;
+        if(frozen())
+            t = t.copy().append(" (!)");
+        tr.draw(matrixStack, t, (int) getX() + 2, (int) getY() + 2, (GavUISettings.getColor("gui.color.foreground")).getAsInt());
         updateSymbol();
-        tr.draw(matrixStack, String.valueOf(symbol), (int) getX2() + symbolOffsetX, (int) getY() + symbolOffsetY, (GavUISettings.getColor("gui.color.foreground")).getAsInt());
+        var s = String.valueOf(symbol);
+
+        tr.draw(matrixStack, s, (int) getX2() + symbolOffsetX, (int) getY() + symbolOffsetY, (GavUISettings.getColor("gui.color.foreground")).getAsInt());
         GuiUtil.drawOutline(Colors.WHITE.getAsFloatArray(), (int) getX(), (int) getY(), (int) getX2(), (int) getY2() + 1, matrixStack);
 
         if (!isOpen()) return;
@@ -126,7 +131,7 @@ public class GuiScroll extends GuiDropdown {
             if (shouldDrawScrollBar()) {
                 drawScrollBox(matrixStack);
                 drawScrollBar(matrixStack);
-                child.setWidth(this.getWidth() - 5);
+                child.shrinkForScrollbar(this);
             }
             if (!child.isParent() && !(child instanceof GuiCycle))
                 child.setBackground(GavUISettings.getColor("gui.color.background"));
@@ -273,6 +278,10 @@ public class GuiScroll extends GuiDropdown {
         if (isHidden()) return false;
         if (mouseWithinGui(x, y)) {
             if (clickedOnChild(x, y, button)) return true;
+            if (button == 1 && isParent()) {
+                setFrozen(!frozen());
+                return true;
+            }
             toggleMenu();
             return true;
         }


### PR DESCRIPTION
This patch fixes an issue where if you were to move a scroll gui to a different location, the scrollbar does not follow. This also implements right clicking on an element to "freeze" it in place, temporarily disabling it from being dragged.